### PR TITLE
Set tc_aws version to 1.3.2

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -54,7 +54,7 @@ tar -jxvf /tmp/jpeg-archive.tar.bz2 -C /usr/bin --wildcards 'jpeg-*'
 pip install \
     remotecv graphicsmagick-engine opencv-engine j2cli \
     Pillow==2.9.0 \
-    tc_aws \
+    tc_aws==1.3.2 \
     thumbor==$THUMBOR_VERSION
 
 pip install https://github.com/zanui/thumbor-plugins/archive/jpegrecompress_add_options.zip


### PR DESCRIPTION
It's nice to know what version of tc_aws this image was built against. Also, 1.3.2 is a recent release which fixes some issues: https://github.com/thumbor-community/aws/issues/29
